### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["sessions", "tide", "async-session", "redis"]
 categories = ["web-programming::http-server", "web-programming", "database"]
 
 [dependencies.redis]
-version = "0.26.1"
+version = "0.27.2"
 features = ["async-std-comp"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 )]
 
 use async_session::{async_trait, serde_json, Result, Session, SessionStore};
-use redis::{aio::Connection, AsyncCommands, Client, IntoConnectionInfo, RedisResult};
+use redis::{aio::MultiplexedConnection, AsyncCommands, Client, IntoConnectionInfo, RedisResult};
 
 /// # RedisSessionStore
 #[derive(Clone, Debug)]
@@ -108,8 +108,8 @@ impl RedisSessionStore {
         }
     }
 
-    async fn connection(&self) -> RedisResult<Connection> {
-        self.client.get_async_std_connection().await
+    async fn connection(&self) -> RedisResult<MultiplexedConnection> {
+        self.client.get_multiplexed_async_std_connection().await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ impl SessionStore for RedisSessionStore {
 
     async fn destroy_session(&self, session: Session) -> Result {
         let mut connection = self.connection().await?;
-        let key = self.prefix_key(session.id().to_string());
+        let key = self.prefix_key(session.id());
         connection.del(key).await?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,11 +134,7 @@ impl SessionStore for RedisSessionStore {
         let () = match session.expires_in() {
             None => connection.set(id, string).await?,
 
-            Some(expiry) => {
-                connection
-                    .set_ex(id, string, expiry.as_secs())
-                    .await?
-            }
+            Some(expiry) => connection.set_ex(id, string, expiry.as_secs()).await?,
         };
 
         Ok(session.into_cookie_value())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl SessionStore for RedisSessionStore {
 
         let mut connection = self.connection().await?;
 
-        match session.expires_in() {
+        let () = match session.expires_in() {
             None => connection.set(id, string).await?,
 
             Some(expiry) => {
@@ -147,7 +147,7 @@ impl SessionStore for RedisSessionStore {
     async fn destroy_session(&self, session: Session) -> Result {
         let mut connection = self.connection().await?;
         let key = self.prefix_key(session.id());
-        connection.del(key).await?;
+        let () = connection.del(key).await?;
         Ok(())
     }
 
@@ -159,7 +159,7 @@ impl SessionStore for RedisSessionStore {
         } else {
             let ids = self.ids().await?;
             if !ids.is_empty() {
-                connection.del(ids).await?;
+                let () = connection.del(ids).await?;
             }
         }
         Ok(())


### PR DESCRIPTION
General maintenance work. There's no dependencies to upgrade at the moment, but this warning was present so can be fixed by the simple method and import rename. 